### PR TITLE
Fix flaky PickAsync_UpdateAddressesWhileRequestingConnection_DoesNotDeadlock test

### DIFF
--- a/test/Grpc.Net.Client.Tests/Balancer/ConnectionManagerTests.cs
+++ b/test/Grpc.Net.Client.Tests/Balancer/ConnectionManagerTests.cs
@@ -576,9 +576,10 @@ public class ConnectionManagerTests
         transportFactory.Transports.ForEach(t => t.Disconnect());
 
         var requestConnectionSyncPoint = new SyncPoint(runContinuationsAsynchronously: true);
+        var connectionRequestedIntercepted = 0;
         testSink.MessageLogged += (w) =>
         {
-            if (w.EventId.Name == "ConnectionRequested")
+            if (w.EventId.Name == "ConnectionRequested" && Interlocked.CompareExchange(ref connectionRequestedIntercepted, 1, 0) == 0)
             {
                 logger.LogInformation("Connection has been requested. Waiting for signal to continue...");
                 requestConnectionSyncPoint.WaitToContinue().Wait();


### PR DESCRIPTION
The test's `MessageLogged` callback intercepted every `ConnectionRequested` log event, but the `SyncPoint` is a one-shot mechanism (backed by `TaskCompletionSource`). After `Continue()` is called, subsequent `WaitToContinue()` calls return immediately.

When `UpdateAddresses` triggers a reconnect that fires additional `ConnectionRequested` events, the callback re-enters and executes inside the subchannel lock, causing state interleaving that leaves `CurrentEndPoint` null while the picker is set to `PickFirstPicker`. `PickAsync` then waits for a new picker that never arrives, timing out after 5 seconds.

**Fix:** Use `Interlocked.CompareExchange` to ensure the callback only intercepts `ConnectionRequested` once, matching the test's intent of pausing exactly one connection request.

Verified stable with 100/100 passes in a loop.