### PR TITLE
Fix flaky DuplexStream_SendToUnimplementedMethod_ThrowError test

### DIFF
--- a/test/FunctionalTests/Client/StreamingTests.cs
+++ b/test/FunctionalTests/Client/StreamingTests.cs
@@ -218,8 +218,17 @@ public class StreamingTests : FunctionalTestBase
 
         await call.ResponseHeadersAsync.DefaultTimeout();
 
+        // Drain the response stream so the call is fully complete before checking status.
+        var ex = Assert.ThrowsAsync<RpcException>(async () =>
+        {
+            while (await call.ResponseStream.MoveNext(CancellationToken.None).DefaultTimeout())
+            {
+            }
+        });
+
         // Assert
         Assert.AreEqual(StatusCode.Unimplemented, call.GetStatus().StatusCode);
+        Assert.AreEqual(StatusCode.Unimplemented, ex!.StatusCode);
     }
 
     [Test]


### PR DESCRIPTION
Fix race condition in `DuplexStream_SendToUnimplementedMethod_ThrowError` where `GetStatus()` throws `InvalidOperationException` because `CallTask` hasn't completed yet.\n\nThe test was awaiting `ResponseHeadersAsync` before calling `GetStatus()`, but receiving response headers doesn't guarantee the internal call is fully complete. The fix drains the response stream (via `MoveNext` which throws `RpcException`) before checking status, ensuring the call is fully finished.